### PR TITLE
Removed unnecessary condition and used correct field

### DIFF
--- a/lib/consul.js
+++ b/lib/consul.js
@@ -117,7 +117,10 @@ function mapServers(list, opts) {
     return s && s.Address
   })
   .map(function (s) {
-    return protocol + '://' + s.ServiceAddress + ':' + (+s.ServicePort || port)
+    if (s.ServiceAddress) {
+      return protocol + '://' + s.ServiceAddress + ':' + (+s.ServicePort || port)
+    }
+    return protocol + '://' + s.Address + ':' + (+s.ServicePort || port)
   })
 }
 

--- a/lib/consul.js
+++ b/lib/consul.js
@@ -117,10 +117,7 @@ function mapServers(list, opts) {
     return s && s.Address
   })
   .map(function (s) {
-    if (s.ServiceAddress) {
-      return s.ServiceAddress
-    }
-    return protocol + '://' + s.Address + ':' + (+s.ServicePort || port)
+    return protocol + '://' + s.ServiceAddress + ':' + (+s.ServicePort || port)
   })
 }
 


### PR DESCRIPTION
Hello.

`ServiceAddress` is generally not enough to reach a specific service; we need `ServicePort` too so the conditional is not really useful.

Also, `Address` is the Consul Agent's address so it is irrelevant when trying to reach a service.

See https://www.consul.io/api/catalog.html#sample-response-3.

This quick change fixes an issue we had with this package but it's certainly not perfect. More work may be needed to obtain a really solid solution.